### PR TITLE
Correct redirection

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,10 +8,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta
-      http-equiv="refresh"
-      content="0; URL=https://memocan40.github.io/TodoList/public/"
-    />
+    <meta http-equiv="refresh" content="0; URL=./public/" />
 
     <link rel="canonical" href="https://memocan40.github.io/TodoList/public/" />
 


### PR DESCRIPTION
When opening the website on a local computer, you should not be redirected to GitHub pages.